### PR TITLE
Add support for stock warrants

### DIFF
--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -14,7 +14,7 @@ from xml.dom import minidom
 
 bsRateXmlUrl = "https://www.bsi.si/_data/tecajnice/dtecbs-l.xml"
 normalAssets = ["STK"]
-derivateAssets = ["CFD", "OPT", "FUT", "FOP"]
+derivateAssets = ["CFD", "OPT", "FUT", "FOP", "WAR"]
 ignoreAssets = ["CASH"]
 
 
@@ -211,6 +211,7 @@ def main():
                         ibTrade.attrib["multiplier"]
                     )
                 """ If trade is an option exercise, tradePrice is set to 0, but closePrice is the one position was settled for """
+                # TODO: handle warrants exercise
                 if (
                     trade["assetCategory"] == "OPT"
                     and ibTrade.attrib["notes"] == "Ex"
@@ -775,7 +776,7 @@ def main():
             Name = xml.etree.ElementTree.SubElement(TItem, "Name").text = trades[0][
                 "description"
             ]
-        if trades[0]["assetCategory"] != "OPT":
+        if trades[0]["assetCategory"] != "OPT" and trades[0]["assetCategory"] != "WAR":
             """ Option descriptions are to long and not accepted by eDavki """
             Code = xml.etree.ElementTree.SubElement(TItem, "Code").text = trades[0][
                 "symbol"
@@ -862,7 +863,7 @@ def main():
             Name = xml.etree.ElementTree.SubElement(TItem, "Name").text = trades[0][
                 "description"
             ]
-        if trades[0]["assetCategory"] != "OPT":
+        if trades[0]["assetCategory"] != "OPT" and trades[0]["assetCategory"] != "WAR":
             """ Option descriptions are to long and not accepted by eDavki """
             Code = xml.etree.ElementTree.SubElement(TItem, "Code").text = trades[0][
                 "symbol"


### PR DESCRIPTION
- Add support for `WAR` (warrant) type of assets
- Omit `Code` and use warrant `description` directly which looks like option description, i.e: `SPCE 25OCT24 11.5 C`. Similar to how options are handled.
- Add  "TODO" for handling warrant exercise. Since I never exercised a warrant, I don't know how IBKR outputs this in XML. Maybe there is a documentation somewhere, I'd have to look that up.

Corresponding issue: https://github.com/jamsix/ib-edavki/issues/8