### PR TITLE
Fill in tax payer contact information in dividend form (Doh_Div)

### DIFF
--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -1110,6 +1110,10 @@ def main():
     else:
         dYear = str(reportYear)
     xml.etree.ElementTree.SubElement(Doh_Div, "Period").text = dYear
+    xml.etree.ElementTree.SubElement(Doh_Div, "EmailAddress").text = taxpayerConfig["email"]
+    xml.etree.ElementTree.SubElement(Doh_Div, "PhoneNumber").text = taxpayerConfig[
+        "telephoneNumber"
+    ]
     xml.etree.ElementTree.SubElement(Doh_Div, "ResidentCountry").text = taxpayerConfig[
         "residentCountry"
     ]


### PR DESCRIPTION
This PR fills in the phone & email taxpayer information in dividend form (Doh_Div). 

Based on https://edavki.durs.si/Documents/Schemas/Doh_Div_3.xsd the following fields are supported:

```
<xs:element name="Doh_Div">
<xs:complexType>
<xs:sequence>
    <xs:element name="Period" type="xs:string" minOccurs="0"/>
    <xs:element name="EmailAddress" type="xs:string" minOccurs="0"/>
    <xs:element name="PhoneNumber" type="xs:string" minOccurs="0"/>
    <xs:element name="ResidentCountry" type="xs:string" minOccurs="0"/>
    <xs:element name="IsResident" type="xs:boolean" default="false" minOccurs="0"/>
    <xs:element name="Locked" type="xs:boolean" default="false" minOccurs="0"/>
</xs:sequence>
</xs:complexType>
</xs:element>
```

On the side note: do you use a code formatter?