### PR TITLE
Fix type name for CFDs

### DIFF
--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -760,7 +760,7 @@ def main():
             Type = xml.etree.ElementTree.SubElement(TItem, "Type").text = "02"
             TypeName = xml.etree.ElementTree.SubElement(
                 TItem, "TypeName"
-            ).text = "financne pogodbe na razliko"
+            ).text = "finančne pogodbe na razliko"
         elif trades[0]["assetCategory"] == "OPT":
             Type = xml.etree.ElementTree.SubElement(TItem, "Type").text = "03"
             TypeName = xml.etree.ElementTree.SubElement(
@@ -847,7 +847,7 @@ def main():
             Type = xml.etree.ElementTree.SubElement(TItem, "Type").text = "02"
             TypeName = xml.etree.ElementTree.SubElement(
                 TItem, "TypeName"
-            ).text = "financne pogodbe na razliko"
+            ).text = "finančne pogodbe na razliko"
         elif trades[0]["assetCategory"] == "OPT":
             Type = xml.etree.ElementTree.SubElement(TItem, "Type").text = "03"
             TypeName = xml.etree.ElementTree.SubElement(


### PR DESCRIPTION
Looks like e-davki started using diacritic string comparison, so using "c" in place of "č" doesn't cut it anymore.

Closes #12

<img width="968" alt="Screen Shot 2021-01-16 at 14 28 33" src="https://user-images.githubusercontent.com/704044/104813131-84258980-5807-11eb-8197-db2b7c2bda0f.png">
<img width="648" alt="Screen Shot 2021-01-16 at 14 28 40" src="https://user-images.githubusercontent.com/704044/104813133-85ef4d00-5807-11eb-90e1-ae5869e679a5.png">
