### PR TITLE
Generate Doh-Obr with Stock Yield Enhancement Program gains

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # InteractiveBrokers -> FURS eDavki konverter
-_Skripta, ki prevede XML poročilo trgovalnih poslov v platformi InteractiveBrokers v XML format primeren za uvoz v obrazce:_
+_Skripta, ki prevede XML poročilo trgovalnih poslov, dividend in obresti Stock Yield Enhancement programa v platformi InteractiveBrokers v XML format primeren za uvoz v obrazce:_
 * _Doh-KDVP - Napoved za odmero dohodnine od dobička od odsvojitve vrednostnih papirjev in drugih deležev ter investicijskih kuponov,_
 * _D-IFI - Napoved za odmero davka od dobička od odsvojitve izvedenih finančnih instrumentov in_
 * _Doh-Div - Napoved za odmero dohodnine od dividend_
+* _Doh-Obr - Napoved za odmero dohodnine od obresti_
 _v eDavkih Finančne uprave_
 
 Poleg pretvorbe vrednosti skripta naredi še konverzijo iz tujih valut v EUR po tečaju Banke Slovenije na dan posla.
@@ -39,9 +40,10 @@ Odpri datoteko **taxpayer.xml** in vnesi svoje davčne podatke.
 1. Vpiši poljuben **Query Name**.
 1. Kot **Date Period** izberi **Custom Date Range**.
 1. Izberi prvi dan v letu za **From Date** in zadnji dan v letu za **To Date**.
+1. Pod **Sections** klikni na **Account Information**. Izberi **IB Entity** in **Account ID**.
 1. Pod **Sections** klikni na **Trades**. Pod Options označi **Executions** in **Closed Lots**. Izberi vse stolpce (**Select All**).
 1. Pod **Sections** klikni na **Corporate Actions**. Izberi vse stolpce (**Select All**).
-1. Pod **Sections** klikni na **Cash Transactions**. Pod Options označi **Dividends**, **Payment in Lieu of Dividends** in **Withholding Tax**. Izberi vse stolpce (**Select All**).
+1. Pod **Sections** klikni na **Cash Transactions**. Pod Options označi **Dividends**, **Payment in Lieu of Dividends**, **Withholding Tax** in **Broker Interest Received**. Izberi vse stolpce (**Select All**).
 1. Pod **Sections** klikni na **Financial Instrument Information**. Izberi vse stolpce (**Select All**).
 1. Vse ostale nastavitve pusti tako kot so.
 1. Na dnu klikni **Save**
@@ -60,6 +62,7 @@ Skripta po uspešni konverziji v lokalnem direktoriju ustvari tri datoteke:
 * Doh-KDVP.xml (datoteka namenjena uvozu v obrazec Doh-KDVP - Napoved za odmero dohodnine od dobička od odsvojitve vrednostnih papirjev in drugih deležev ter investicijskih kuponov)
 * D-IFI.xml (datoteka namenjena uvozu v obrazec D-IFI - Napoved za odmero davka od dobička od odsvojitve izvedenih finančnih instrumentov)
 * D-Div.xml (datoteka namenjena uvozu v obrazec D-Div - Napoved za odmero dohodnine od dividend)
+* Doh-Obr.xml (datoteka namenjena uvozu v obrazec Doh-Obr - Napoved za odmero dohodnine od obresti)
 
 #### -y <leto> (opcijsko)
 Leto za katerega se izdelajo popisni listi. Privzeto trenutno leto.
@@ -73,8 +76,11 @@ eDavki ne omogočajo dodajanje popisnih listov za tekoče leto, temveč le za pr
 Obrazec Doh-Div zahteva dodatne podatke o podjetju, ki je izplačalo dividende (identifikacijska številka, naslov, ...), ki jih v izvirnih podatkih IBja ni. Ob prvi uporabi, skripta prenese datoteki `companies.xml` in `relief-statement.xml`, ki že vsebujeta nekaj podjetij in sporazumov o izogibanju dvojnega obdavčevanja, ostale lahko dodaš sam, ali manjkajoče podatke po uvozu obrazca vneseš v eDavkih.
 *Če boš v `companies.xml` vnesel več novih podjetij, naredi pull request.*
 
+#### Podatki o podružnicah IB za obrazec Doh-Obr
+Obrazec Doh-Obr zahteva dodatne podatke o podružnici IB, ki je izplačevalka obresti Stock Yield Enhancement programa (identifikacijska številka, naziv, naslov, država) in jih v izvirnih podatkih IB-ja ni. Ob prvi uporabi skripta prenese datoteko `ib-affiliates.xml`, ki vsebuje zahtevane podatke za IB United Kingdom, IB Central Europe, IB Ireland in IB Luxembourg, po potrebi pa lahko te podatke spremeniš ali dodaš.
+
 ### Uvoz v eDavke
-1. V meniju **Dokument** klikni **Uvoz**. Izberi eno izmed generiranih datotek (Doh-KDVP.xml, D-IFI, Doh-Div) in jo **Prenesi**.
+1. V meniju **Dokument** klikni **Uvoz**. Izberi eno izmed generiranih datotek (Doh-KDVP.xml, D-IFI.xml, Doh-Div.xml, Doh-Obr.xml) in jo **Prenesi**.
 1. Preveri izpolnjene podatke in dodaj manjkajoče.
 1. Pri obrazcih Doh-KDVP in D-IFI je na seznamu popisnih listov po en popisni list za vsak vrednostni papir (ticker).
 1. Klikni na ime vrednostnega papirja in odpri popisni list.

--- a/generators/doh_obr.py
+++ b/generators/doh_obr.py
@@ -1,0 +1,212 @@
+import urllib.request
+import sys
+import xml.etree.ElementTree
+import os.path
+from xml.dom import minidom
+
+""" Fetch ib-affiliates.xml from GitHub if it doesn't exist and use the data for Doh-Obr.xml """
+def getIbAffiliateInfo(ibEntities, accountId):
+    ibAffiliateCode = getIbEntityCode(ibEntities, accountId)
+    if not os.path.isfile("ib-affiliates.xml"):
+        urllib.request.urlretrieve(
+            "https://github.com/jamsix/ib-edavki/raw/master/ib-affiliates.xml",
+            "ib-affiliates.xml",
+        )
+    if os.path.isfile("ib-affiliates.xml"):
+        ibAffiliateInfos = xml.etree.ElementTree.parse("ib-affiliates.xml").getroot()
+        for affiliate in ibAffiliateInfos:
+            if affiliate.find("code").text == str(ibAffiliateCode):
+                return {
+                    "code": affiliate.find("code").text,
+                    "name": affiliate.find("name").text,
+                    "taxNumber": affiliate.find("taxNumber").text,
+                    "address": affiliate.find("address").text,
+                    "country": affiliate.find("country").text,
+                }
+            else:
+                return {
+                    "code": "",
+                    "name": "",
+                    "taxNumber": "",
+                    "address": "",
+                    "country": "",
+                }
+
+""" Get the IB entity matching account id """
+def getIbEntityCode(ibEntities, accountId):
+    for ibEntity in ibEntities:
+        if (ibEntity["accountId"] == accountId):
+            return ibEntity["ibEntity"]
+        else:
+            print("IB Entity for account "
+                + accountId + " "
+                + "not found in flex statement. "
+                + "Check your report settings.")
+            return None
+
+""" Get interest from IB XML """
+def generate(taxpayerConfig,
+             ibEntities,
+             ibCashTransactionsList,
+             rates,
+             reportYear,
+             test,
+             testYearDiff):
+    interests = []
+    for ibCashTransactions in ibCashTransactionsList:
+        if ibCashTransactions is None:
+            continue
+        for ibCashTransaction in ibCashTransactions:
+            if (
+                ibCashTransaction.tag == "CashTransaction"
+                and ibCashTransaction.get("dateTime").startswith(str(reportYear))
+                and ibCashTransaction.get("type")
+                in ["Broker Interest Received"]
+            ):
+                interest = {
+                    "accountId": ibCashTransaction.get("accountId"),
+                    "currency": ibCashTransaction.get("currency"),
+                    "amount": float(ibCashTransaction.get("amount")),
+                    "description": ibCashTransaction.get("description"),
+                    "dateTime": ibCashTransaction.get("dateTime"),
+                    "tax": 0,
+                    "taxEUR": 0,
+                }
+
+                """ Convert amount to EUR """
+                if interest["currency"] == "EUR":
+                    interest["amountEUR"] = interest["amount"]
+                else:
+                    date = interest["dateTime"][0:8]
+                    currency = interest["currency"]
+                    if date in rates and currency in rates[date]:
+                        rate = float(rates[date][currency])
+                    else:
+                        for i in range(0, 6):
+                            date = str(int(date) - 1)
+                            if date in rates and currency in rates[date]:
+                                rate = float(rates[date][currency])
+                                print(
+                                    "There is no exchange rate for "
+                                    + str(interest["dateTime"][0:8])
+                                    + ", using "
+                                    + str(date)
+                                )
+                                break
+                            if i == 6:
+                                sys.exit(
+                                    "Error: There is no exchange rate for " + str(date)
+                                )
+                    interest["amountEUR"] = interest["amount"] / rate
+                interests.append(interest)
+
+    """ Merge multiple dividends or payments in lieu of dividents on the same day from the same company into a single entry """
+    mergedInterests = []
+    for interest in interests:
+        merged = False
+        for mergedInterest in mergedInterests:
+            if interest["dateTime"][0:8] == mergedInterest["dateTime"][0:8]:
+                mergedInterest["amountEUR"] = (
+                    mergedInterest["amountEUR"] + interest["amountEUR"]
+                )
+                mergedInterest["taxEUR"] = mergedInterest["taxEUR"] + interest["taxEUR"]
+                merged = True
+                break
+        if merged == False:
+            mergedInterests.append(interest)
+    interests = mergedInterests
+
+    """ Generate Doh-Obr.xml """
+    envelope = xml.etree.ElementTree.Element(
+        "Envelope", xmlns="http://edavki.durs.si/Documents/Schemas/Doh_Obr_2.xsd"
+    )
+    envelope.set(
+        "xmlns:edp", "http://edavki.durs.si/Documents/Schemas/EDP-Common-1.xsd"
+    )
+    header = xml.etree.ElementTree.SubElement(envelope, "edp:Header")
+    taxpayer = xml.etree.ElementTree.SubElement(header, "edp:taxpayer")
+    xml.etree.ElementTree.SubElement(taxpayer, "edp:taxNumber").text = taxpayerConfig[
+        "taxNumber"
+    ]
+    xml.etree.ElementTree.SubElement(
+        taxpayer, "edp:taxpayerType"
+    ).text = taxpayerConfig["taxpayerType"]
+    xml.etree.ElementTree.SubElement(taxpayer, "edp:name").text = taxpayerConfig["name"]
+    xml.etree.ElementTree.SubElement(taxpayer, "edp:address1").text = taxpayerConfig[
+        "address1"
+    ]
+    xml.etree.ElementTree.SubElement(taxpayer, "edp:city").text = taxpayerConfig["city"]
+    xml.etree.ElementTree.SubElement(taxpayer, "edp:postNumber").text = taxpayerConfig[
+        "postNumber"
+    ]
+    xml.etree.ElementTree.SubElement(taxpayer, "edp:postName").text = taxpayerConfig[
+        "postName"
+    ]
+    xml.etree.ElementTree.SubElement(envelope, "edp:AttachmentList")
+    xml.etree.ElementTree.SubElement(envelope, "edp:Signatures")
+    body = xml.etree.ElementTree.SubElement(envelope, "body")
+    xml.etree.ElementTree.SubElement(body, "edp:bodyContent")
+    Doh_Obr = xml.etree.ElementTree.SubElement(body, "Doh_Obr")
+    if test == True:
+        dYear = str(reportYear + testYearDiff)
+    else:
+        dYear = str(reportYear)
+    xml.etree.ElementTree.SubElement(Doh_Obr, "Period").text = dYear
+    if test == True:
+        xml.etree.ElementTree.SubElement(Doh_Obr, "DocumentWorkflowID").text = "I"
+    else:
+        xml.etree.ElementTree.SubElement(Doh_Obr, "DocumentWorkflowID").text = "O"
+    xml.etree.ElementTree.SubElement(Doh_Obr, "Email").text = taxpayerConfig[
+        "email"
+    ]
+    xml.etree.ElementTree.SubElement(Doh_Obr, "TelephoneNumber").text = taxpayerConfig[
+        "telephoneNumber"
+    ]
+    xml.etree.ElementTree.SubElement(Doh_Obr, "ResidentOfRepublicOfSlovenia"
+    ).text = taxpayerConfig[
+        "isResident"
+    ]
+    xml.etree.ElementTree.SubElement(Doh_Obr, "Country").text = taxpayerConfig[
+        "residentCountry"
+    ]
+
+    interests = sorted(interests, key=lambda k: k["dateTime"][0:8])
+    for interest in interests:
+        if round(interest["amountEUR"], 2) <= 0:
+            continue
+        Interest = xml.etree.ElementTree.SubElement(Doh_Obr, "Interest")
+
+        ibAffiliateInfo = getIbAffiliateInfo(ibEntities, interest["accountId"])
+
+        xml.etree.ElementTree.SubElement(Interest, "Date").text = (
+            dYear + "-" + interest["dateTime"][4:6] + "-" + interest["dateTime"][6:8]
+        )
+        xml.etree.ElementTree.SubElement(
+            Interest, "IdentificationNumber"
+        ).text = ibAffiliateInfo["taxNumber"]
+        xml.etree.ElementTree.SubElement(Interest, "Name").text = ibAffiliateInfo[
+            "name"
+        ]
+        xml.etree.ElementTree.SubElement(Interest, "Address").text = ibAffiliateInfo[
+            "address"
+        ]
+        xml.etree.ElementTree.SubElement(Interest, "Country").text = ibAffiliateInfo[
+            "country"
+        ]
+        xml.etree.ElementTree.SubElement(Interest, "Type").text = "2"
+        xml.etree.ElementTree.SubElement(Interest, "Value").text = "{0:.2f}".format(
+            interest["amountEUR"]
+        )
+        xml.etree.ElementTree.SubElement(
+            Interest, "ForeignTax"
+        ).text = "{0:.2f}".format(interest["taxEUR"])
+        if "country" in interest:
+            xml.etree.ElementTree.SubElement(Interest, "Country2").text = interest[
+                "country"
+            ]
+
+    xmlString = xml.etree.ElementTree.tostring(envelope)
+    prettyXmlString = minidom.parseString(xmlString).toprettyxml(indent="\t")
+    with open("Doh-Obr.xml", "w", encoding="utf-8") as f:
+        f.write(prettyXmlString)
+        print("Doh-Obr.xml created")

--- a/ib-affiliates.xml
+++ b/ib-affiliates.xml
@@ -1,0 +1,30 @@
+<ibAffiliates>
+   <ibAffiliate>
+      <code>IB-UK</code>
+      <name>Interactive Brokers (U.K.) Ltd.</name>
+      <taxNumber>03958476</taxNumber>
+      <address>Level 20 Heron Tower, 110 Bishopsgate, London EC2N 4AY</address>
+      <country>GB</country>
+   </ibAffiliate>
+   <ibAffiliate>
+      <code>IB-CE</code>
+      <name>Interactive Brokers Central Europe Zrt.</name>
+      <taxNumber>01-10-141029</taxNumber>
+      <address>Madach Imre ut 13-14, Floor 5, Budapest, 1075</address>
+      <country>HU</country>
+   </ibAffiliate>
+   <ibAffiliate>
+      <code>IB-IE</code>
+      <name>Interactive Brokers Ireland Limited</name>
+      <taxNumber>657406</taxNumber>
+      <address>10 Earlsfort Terrace, Dublin 2 D02 T380</address>
+      <country>IE</country>
+   </ibAffiliate>
+   <ibAffiliate>
+      <code>IB-LUX</code>
+      <name>Interactive Brokers Luxembourg SARL</name>
+      <taxNumber>B229091</taxNumber>
+      <address>4 rue Robert Stumper, L-2557 Luxembourg</address>
+      <country>LU</country>
+   </ibAffiliate>
+</ibAffiliates>

--- a/relief-statements.xml
+++ b/relief-statements.xml
@@ -5,14 +5,34 @@
     </reliefStatement>
     <reliefStatement>
         <country>CA</country>
-        <statement>Konvencija med Vlado Republike Slovenije in Vlado Kanade o izogibanju dvojnega obdavčevanja in preprečevanju davčnih utaj v zvezi z davki od dohodka in premoženja (BCAIDO)</statement>
+        <statement>6/01, 2b odstavek 10. člena</statement>
     </reliefStatement>
     <reliefStatement>
         <country>CN</country>
-        <statement>Sporazum med Vlado Republike Slovenije in Vlado Republike Kitajske o izogibanju dvojnega obdavčevanja in preprečevanju davčnih utaj, v zvezi z davki na dohodek</statement>
+        <statement>13/95, 2. odstavek 10. člena</statement>
     </reliefStatement>
     <reliefStatement>
         <country>US</country>
-        <statement>Konvencija med Republiko Slovenijo in Združenimi državami Amerike o izogibanju dvojnega obdavčevanja (10. člen, 2 b)</statement>
+        <statement>10/01, 2b odstavek 10. člena</statement>
+    </reliefStatement>
+    <reliefStatement>
+        <country>DE</country>
+        <statement>22/06, 2b odstavek 10. člena</statement>
+    </reliefStatement>
+    <reliefStatement>
+        <country>NO</country>
+        <statement>7/09, 2c odstavek 10. člena</statement>
+    </reliefStatement>
+    <reliefStatement>
+        <country>RU</country>
+        <statement>11/96, 2. odstavek 10. člena</statement>
+    </reliefStatement>
+    <reliefStatement>
+        <country>CH</country>
+        <statement>15/97, 5/137, 2. odstavek 10. člena</statement>
+    </reliefStatement>
+    <reliefStatement>
+        <country>IN</country>
+        <statement>13/04, 2b odstavek 10. člena</statement>
     </reliefStatement>
 </treaties>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="ib_edavki",
-    version="1.3.0",
+    version="1.4.0",
     py_modules=["ib_edavki"],
     python_requires=">=3",
     entry_points={


### PR DESCRIPTION
### New features
- **Report Stock Yield Enhancement Program gains as interest on Doh-Obr form**
`ib-affiliates.xml` contains information about IB affiliates. Company registration numbers are used as tax identification numbers as I was not able to find any other relevant tax id

### Changes/fixes
- **Support multiple accounts in one flex statement**
- New data added to `relief-statements.xml` and modified existing descriptions to contain information about paragraph/article of treaty, which is now referenced by international treaty number (still valid but easier to read)
- Some unused variables removed and lint errors fixed
- Updated readme

Closes #7 
Closes #6 