### PR TITLE
Fix dividend withholding tax calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Odpri datoteko **taxpayer.xml** in vnesi svoje davčne podatke.
 1. Na dnu klikni **Save**
 1. Na dnu klikni **Continue** in nato **Create**.
 1. V pogledu **Reports > Flex Queries** se je pojavil novo narejeni report. Klikni **Run**, shrani XML.
-1. Ponovi postopek za vsako leto trgovanja, če si trgoval v letih 2016, 2017 in 2018, generiraj 3 reporte, po enega za vsako leto.
+1. Ponovi postopek za vsako leto trgovanja, če si trgoval v letih 2016, 2017 in 2018, generiraj 3 reporte, po enega za vsako leto. Za pravilen izračun tujega davka na dividende (Withholding Tax) je potrebno generirati tudi report tekočega leta, saj so nekateri obračuni poročani za nazaj.
 
 ### Konverzija IB poročila v popisne liste primerne za uvoz v eDavke
 

--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -1155,10 +1155,10 @@ def main():
                         ):
                             closestDividend = dividend
                 if closestDividend:
-                    closestDividend["tax"] = -float(ibCashTransaction.attrib["amount"])
+                    closestDividendTax = -float(ibCashTransaction.attrib["amount"])
                     """ Convert amount to EUR """
                     if ibCashTransaction.attrib["currency"] == "EUR":
-                        closestDividend["taxEUR"] = closestDividend["tax"]
+                        closestDividend["taxEUR"] += closestDividendTax
                     else:
                         date = ibCashTransaction.attrib["dateTime"][0:8]
                         currency = ibCashTransaction.attrib["currency"]
@@ -1181,7 +1181,7 @@ def main():
                                         "Error: There is no exchange rate for "
                                         + str(date)
                                     )
-                        closestDividend["taxEUR"] = closestDividend["tax"] / rate
+                        closestDividend["taxEUR"] += closestDividendTax / rate
 
     """ Merge multiple dividends or payments in lieu of dividents on the same day from the same company into a single entry """
     mergedDividends = []


### PR DESCRIPTION
This fixes #4 . The issue was twofold:

1. Some Withholding Tax is reported in the next year's flex report (although the date matches the one of the dividend from the previous year). An example fo this are REITs for which the _qualified_ status is determined at the end of the year and taxation can change accordingly.
2. The script didn't take into account that multiple Withholding Tax transactions related to the same dividend payout are also possible. A (shortened) example from the flex report (note dateTime and reportDate):

```
<CashTransaction currency="USD" symbol="SPG" description="SPG(US8288061091) CASH DIVIDEND USD 1.30 PER SHARE - US TAX" dateTime="20201023;202000" settleDate="20201023" amount="10.14" type="Withholding Tax" reportDate="20210119" />
<CashTransaction currency="USD" symbol="SPG" description="SPG(US8288061091) CASH DIVIDEND USD 1.30 PER SHARE - US TAX"  dateTime="20201023;202000" settleDate="20201023" amount="-9.87" type="Withholding Tax" reportDate="20210119"  />
<CashTransaction currency="USD" symbol="SPG" description="SPG(US8288061091) PAYMENT IN LIEU OF DIVIDEND - US TAX"  dateTime="20201023;202000" settleDate="20201023" amount="0.59" type="Withholding Tax" reportDate="20210119" />
<CashTransaction currency="USD" symbol="SPG" description="SPG(US8288061091) PAYMENT IN LIEU OF DIVIDEND - US TAX"  dateTime="20201023;202000" settleDate="20201023" amount="-0.57" type="Withholding Tax" reportDate="20210119" />
```

Please check the changes with your reports and compare with previous Doh-Div.xml.