### PR TITLE
Fix split rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.xml
 *.bat
 *.pyc
+.idea
+__pycache__


### PR DESCRIPTION
In 2022 there was an SLG split, only one, that's indicated with two rows in IBKR reports
```
SLG(US78440X8048) SPLIT 10000 FOR 10306 (SLG, SL GREEN REALTY CORP, US78440X8873)
SLG(US78440X8048) SPLIT 10000 FOR 10306 (SLG, SL GREEN REALTY CORP, US78440X8048)
```
Note the different `isin`. With this patch the split is handled properly while before it was applied twice.