### PR TITLE
Warn about missing entries in companies.xml

### DIFF
--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -1088,6 +1088,8 @@ def main():
 
     """ Get dividends from IB XML """
     dividends = []
+    missingCompanies = set()
+
     for ibCashTransactions in ibCashTransactionsList:
         if ibCashTransactions is None:
             continue
@@ -1113,6 +1115,7 @@ def main():
                 dividend["securityID"] = ibCashTransaction.attrib["securityID"]
                 if dividend["securityID"] == "":
                     dividend["securityID"] = dividend["conid"]
+
                 if companies and dividend["symbol"] in companies:
                     dividend["name"] = companies[dividend["symbol"]]["name"]
                     dividend["taxNumber"] = companies[dividend["symbol"]]["taxNumber"]
@@ -1123,7 +1126,7 @@ def main():
                             "reliefStatement"
                         ]
                 else:
-                    print("No companies.xml entry for " + dividend["symbol"])
+                    missingCompanies.add((dividend["conid"], dividend["symbol"]))
 
                 """ Convert amount to EUR """
                 if dividend["currency"] == "EUR":
@@ -1133,6 +1136,7 @@ def main():
                         dividend["dateTime"][0:8], dividend["currency"], rates
                     )
                 dividends.append(dividend)
+
         for ibCashTransaction in ibCashTransactions:
             if (
                 ibCashTransaction.tag == "CashTransaction"
@@ -1192,6 +1196,12 @@ def main():
                         ibCashTransaction.attrib["currency"],
                         rates,
                     )
+
+    if len(missingCompanies) > 0:
+        explanation = "companies.xml is missing the following symbols (conids): " 
+        missing = map(lambda x: x[1] + " (" + x[0] + ")", missingCompanies)
+        readme = " - more info: https://github.com/jamsix/ib-edavki#dodatni-podatki-o-podjetju-za-obrazec-doh-div-opcijsko"
+        print(explanation + ", ".join(missing) + readme)
 
     """ Dividends can be reversed. If there is a reversal, remove both the reversal
         and the original dividend.

--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -1122,6 +1122,9 @@ def main():
                         dividend["reliefStatement"] = companies[dividend["symbol"]][
                             "reliefStatement"
                         ]
+                else:
+                    print("No companies.xml entry for " + dividend["symbol"])
+
                 """ Convert amount to EUR """
                 if dividend["currency"] == "EUR":
                     dividend["amountEUR"] = dividend["amount"]


### PR DESCRIPTION
Kako običajno dodajate manjkajoče vnose v companies.xml? Jaz sem do lani šel po napakah javljenih na edavkih. Lani sem se poslužil tega malega popravka. Letos mi je prišel spet prav, tako da sem se odločil predlagati to spremembo.

Primer izpisa s to spremembo:
```
There is no exchange rate for 20190501, using 20190430
There is no exchange rate for 20190501, using 20190430
There is no exchange rate for 20201011, using 20201009
There is no exchange rate for 20201011, using 20201009
There is no exchange rate for 20201011, using 20201009
There is no exchange rate for 20220418, using 20220414
There is no exchange rate for 20220418, using 20220414
There is no exchange rate for 20201011, using 20201009
There is no exchange rate for 20220418, using 20220414
There is no exchange rate for 20190422, using 20190418
There is no exchange rate for 20220418, using 20220414
There is no exchange rate for 20220418, using 20220414
There is no exchange rate for 20220515, using 20220513
There is no exchange rate for 20220821, using 20220819
There is no exchange rate for 20220403, using 20220401
There is no exchange rate for 20220821, using 20220819
Doh-KDVP.xml created (includes trades from years 2017, 2018, 2019, 2020, 2021, 2022)
D-IFI.xml created (includes no trades)
Missing companies.xml entry for FRES
Missing companies.xml entry for MO
Missing companies.xml entry for TTE
Missing companies.xml entry for FCX
Missing companies.xml entry for FCX
Missing companies.xml entry for XOM
Missing companies.xml entry for AEM
Missing companies.xml entry for GOLD
Missing companies.xml entry for NEM
Missing companies.xml entry for TTE
Missing companies.xml entry for RIO
Missing companies.xml entry for RIO
Missing companies.xml entry for MO
Missing companies.xml entry for FCX
Missing companies.xml entry for XOM
Missing companies.xml entry for AEM
Missing companies.xml entry for GOLD
Missing companies.xml entry for NEM
Missing companies.xml entry for BTG
Missing companies.xml entry for MO
Missing companies.xml entry for TTE
Missing companies.xml entry for FCX
Missing companies.xml entry for XOM
Missing companies.xml entry for AEM
Missing companies.xml entry for GOLD
Missing companies.xml entry for NEM
Missing companies.xml entry for RIO
Missing companies.xml entry for MO
Missing companies.xml entry for TTE
Missing companies.xml entry for FCX
Missing companies.xml entry for XOM
Missing companies.xml entry for AEM
Missing companies.xml entry for GOLD
Missing companies.xml entry for KGC
Missing companies.xml entry for TTE
Missing companies.xml entry for NEM
SAN 20220510;202000 dividend of 33.3 has been reversed, removing.
SAN 20220510;202000 dividend of 33.31 has been reversed, removing.
SHELL.DIV 20220919;202000 dividend of 25.24 has been reversed, removing.
Doh-Div.xml created
Doh-Obr.xml created
```

Simboli se podvajajo ... je to preveč šuma? Bi tole potrebovalo opcijski parameter?