### PR TITLE
Add ASML to companies

### DIFF
--- a/companies.xml
+++ b/companies.xml
@@ -2012,4 +2012,12 @@
         <address>56 Neil Rd, Singapore 088830</address>
         <country>SG</country>
     </company>
+    <company>
+        <conid>117589399</conid>
+        <symbol>ASML</symbol>
+        <name>ASML Holding N.V.</name>
+        <taxNumber>NL803441526B01</taxNumber>
+        <address>De Run 6501 5504 DR, Veldhoven, Noord-Brabant</address>
+        <country>NL</country>
+    </company>
 </companies>


### PR DESCRIPTION
Davčna številka NL803441526B01 presega dovoljeno število znakov, zato se v uvoženem Doh-Div ne pojavi (#86). V svojem reportu sem ročno dodal identifikacijsko številko 17052456.