### PR TITLE
Use tradePrice instead of closePrice when computing profit on exercised options

### DIFF
--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -343,18 +343,6 @@ def main():
                     trade["tradePrice"] = trade["tradePrice"] * float(
                         ibTrade.attrib["multiplier"]
                     )
-                """ If trade is an option exercise, tradePrice is set to 0, but closePrice is the one position was settled for """
-                # TODO: handle warrants exercise
-                if (
-                    trade["assetCategory"] == "OPT"
-                    and ibTrade.attrib["notes"] == "Ex"
-                    and ibTrade.attrib["closePrice"] != ""
-                ):
-                    trade["tradePrice"] = ibTrade.attrib["closePrice"]
-                    if "multiplier" in ibTrade.attrib:
-                        trade["tradePrice"] = float(
-                            ibTrade.attrib["closePrice"]
-                        ) * float(ibTrade.attrib["multiplier"])
 
                 lastTrade = trade
 


### PR DESCRIPTION
Based off discussion in #94, I believe that exercised call options worth nothing and that aligns with how IB report exercised options, as basically closed at `0` and `tradePrice` already reflects that. I ran this patch on my dataset and the only change I noticed was that exercised call option is now worth $0 as opposed to `closePrice` as before.