### PR TITLE
Fixed a bug with comparison of transactionIDs

### DIFF
--- a/companies.xml
+++ b/companies.xml
@@ -1,5 +1,13 @@
 <companies>
     <company>
+        <conid>13013300</conid>
+        <symbol>APC</symbol>
+        <name>Apple Inc</name>
+        <taxNumber>942404110</taxNumber>
+        <address>1 Infinite Loop, Cupertino, CA 95014</address>
+        <country>US</country>
+    </company>
+    <company>
         <conid>265598</conid>
         <symbol>AAPL</symbol>
         <name>Apple Inc</name>
@@ -77,6 +85,7 @@
         <country>US</country>
     </company>
     <company>
+      <conid>12973838</conid>
         <symbol>JNJ</symbol>
         <name>Johnson &amp; Johnson</name>
         <taxNumber>221024240</taxNumber>
@@ -105,6 +114,14 @@
         <name>3M Company</name>
         <taxNumber>043205742</taxNumber>
         <address>3m Center 224-2w-15, St. Paul, MN 55144-1000</address>
+        <country>US</country>
+    </company>
+    <company>
+        <conid>12178239</conid>
+        <symbol>MSF</symbol>
+        <name>Microsoft Corp</name>
+        <taxNumber>911144442</taxNumber>
+        <address>One Microsoft Way, Redmond, WA 98052-6399</address>
         <country>US</country>
     </company>
     <company>
@@ -790,6 +807,14 @@
         <country>US</country>
     </company>
     <company>
+        <conid>128884495</conid>
+        <symbol>VUSA</symbol>
+        <name>Vanguard S&amp;P 500 UCITS ETF</name>
+        <taxNumber>00B3XXRP09</taxNumber>
+        <address>70 Sir John Rogerson's Quay Dublin 2 Ireland</address>
+        <country>IE</country>
+    </company>
+    <company>
         <symbol>VWRD</symbol>
         <name>Vanguard FTSE All-World UCITS ETF</name>
         <taxNumber>00B3RBWM25</taxNumber>
@@ -1304,6 +1329,7 @@
         <country>US</country>
     </company>
     <company>
+        <conid>8894</conid>
         <symbol>KO</symbol>
         <name>The Coca-Cola Company</name>
         <taxNumber>876272550</taxNumber>

--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -1141,8 +1141,8 @@ def main():
                         dividend["dateTime"][0:8]
                         == ibCashTransaction.attrib["dateTime"][0:8]
                         and dividend["symbol"] == ibCashTransaction.attrib["symbol"]
-                        and dividend["transactionID"]
-                        < ibCashTransaction.attrib["transactionID"]
+                        and int(dividend["transactionID"])
+                        < int(ibCashTransaction.attrib["transactionID"])
                     ):
                         potentiallyMatchingDividends.append(dividend)
 


### PR DESCRIPTION
This merge should fix https://github.com/jamsix/ib-edavki/issues/100. It also adds a few missing companies and `conid`s.


### Bug

`transactionID`s were compared lexicographically, as strings, instead of by their numerical value.

### Explanation:

The usual case is that the transactionIDs of the witholding tax and the dividend are close - meaning that they have the same number of digits. For example the `symbol` **MSF**:
```python
dividend["transactionID"] == 412270322
ibCashTransaction["transactionID"] == 412270323
```
 Hence the original code worked most of the time, because lexicograpical comparison is the same as numerical when the numbers have the same number of digits. 
 
 But this is not an invariant. Some transactions may be far away (measured in how many transactions transpired between them). For example the symbol **APC**:
```python
dividend["transactionID"] == 9750589
ibCashTransaction["transactionID"] == 13534671
```

Where the lexicographic comparison 
```python
"9750589" < "13534671"
```
returns `False`.

This merge fixes this by casting the strings to integers before the comparison.
