### PR TITLE
Fixed: always check only for the first ib affiliates

### DIFF
--- a/generators/doh_obr.py
+++ b/generators/doh_obr.py
@@ -23,14 +23,14 @@ def getIbAffiliateInfo(ibEntities, accountId):
                     "address": affiliate.find("address").text,
                     "country": affiliate.find("country").text,
                 }
-            else:
-                return {
-                    "code": "",
-                    "name": "",
-                    "taxNumber": "",
-                    "address": "",
-                    "country": "",
-                }
+
+        return {
+            "code": "",
+            "name": "",
+            "taxNumber": "",
+            "address": "",
+            "country": "",
+        }
 
 """ Get the IB entity matching account id """
 def getIbEntityCode(ibEntities, accountId):

--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -116,7 +116,7 @@ def main():
     parser.add_argument(
         "ibXmlFiles",
         metavar="ib-xml-file",
-        help="InteractiveBrokers XML ouput file(s) (see README.md on how to generate one)",
+        help="InteractiveBrokers XML output file(s) (see README.md on how to generate one)",
         nargs="+",
     )
     parser.add_argument(


### PR DESCRIPTION
In the previous version of the code, `getIbAffiliateInfo()` returned empty data if the first entry in `ibAffiliateInfos` had a different code.