### PR TITLE
Feature/old file check

### DIFF
--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -169,7 +169,9 @@ def main():
 
     """ Fetch companies.xml from GitHub if it doesn't exist or hasn't been updated for a month and use the data for Doh-Div.xml """
     companies = {}
-    if not os.path.isfile("companies.xml") or datetime.datetime.fromtimestamp(os.path.getctime("companies.xml")) < (datetime.datetime.now() - datetime.timedelta(days=30)):
+
+    # ZIGA: Is check for old file really needed? 
+    if not os.path.isfile("companies.xml"): # or datetime.datetime.fromtimestamp(os.path.getctime("companies.xml")) < (datetime.datetime.now() - datetime.timedelta(days=30)):
         r = requests.get(
             "https://github.com/jamsix/ib-edavki/raw/master/companies.xml",
             headers={"User-Agent": userAgent}


### PR DESCRIPTION
Here is my proposal to remove the "old" _company.xml_ file check.

It is rather anoying when modiying that file localy and all changes are gone after script is run as file timedate has not changed.

After I localy changed the file (and save it) testing out the implementation yields the old date file, not 02.01.2024 as expected:
![image](https://github.com/user-attachments/assets/c6115e5e-cc2b-404d-9ad5-f8d29e97d173)

Maybe the given implementation should be improved or is this just the way Win is dealing with the files. Unfortunatelly I don't have more time to investigate into that, thats why I simply comented out it out :) I now its not the proper solution, but someone might find that usefull. 

What do you think about that? 

