### PR TITLE
Ignore levelOfDetail=SUMMARY CashTransactions

### DIFF
--- a/generators/doh_obr.py
+++ b/generators/doh_obr.py
@@ -72,6 +72,9 @@ def generate(
             continue
 
         for ibCashTransaction in ibCashTransactions:
+            """ Ignore levelOfDetail="SUMMARY" CashTransactions """
+            if ibCashTransaction.attrib["transactionID"] == ""
+                continue
             if (
                 ibCashTransaction.tag == "CashTransaction"
                 and ibCashTransaction.get("dateTime").startswith(str(reportYear))
@@ -90,6 +93,9 @@ def generate(
                 interests.append(interest)
 
         for ibCashTransaction in ibCashTransactions:
+            """ Ignore levelOfDetail="SUMMARY" CashTransactions """
+            if ibCashTransaction.attrib["transactionID"] == ""
+                continue
             if (
                 ibCashTransaction.tag == "CashTransaction"
                 and ibCashTransaction.attrib["dateTime"].startswith(str(reportYear))

--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -1102,6 +1102,9 @@ def main():
         if ibCashTransactions is None:
             continue
         for ibCashTransaction in ibCashTransactions:
+            """ Ignore levelOfDetail="SUMMARY" CashTransactions """
+            if ibCashTransaction.attrib["transactionID"] == ""
+                continue
             if (
                 ibCashTransaction.tag == "CashTransaction"
                 and ibCashTransaction.attrib["dateTime"].startswith(str(reportYear))
@@ -1147,6 +1150,9 @@ def main():
 
         missing_dividends_for_witholding_tax = defaultdict(lambda: set())
         for ibCashTransaction in ibCashTransactions:
+            """ Ignore levelOfDetail="SUMMARY" CashTransactions """
+            if ibCashTransaction.attrib["transactionID"] == ""
+                continue
             if (
                 ibCashTransaction.tag == "CashTransaction"
                 and ibCashTransaction.attrib["dateTime"].startswith(str(reportYear))


### PR DESCRIPTION
We had users reporting `transactionID` related errors. We found out, they mistakenly added Summary CashTransactions into the output. These have no `transactionID` and are useless for our purpose, but break the script.  Clearly they haven't followed the README on how to generate the output, but sometimes it's easier to fix the code than support people.