### PR TITLE
Fix Doh-Div dividend payer title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.xml
 *.bat
 *.pyc

--- a/ib_edavki.py
+++ b/ib_edavki.py
@@ -1336,15 +1336,6 @@ def main():
                     dividends.remove(reversal)
                     break
 
-    """ Get securities info from IB XML """
-    for ibSecuritiesInfo in ibSecuritiesInfoList:
-        if ibSecuritiesInfo is None:
-            continue
-        for ibSecurityInfo in ibSecuritiesInfo:
-            if ibSecurityInfo.attrib["conid"]:
-                for dividend in dividends:
-                    if ibSecurityInfo.attrib["conid"] == dividend["conid"]:
-                        dividend["name"] = ibSecurityInfo.attrib["description"]
 
     """ Generate Doh-Div.xml """
     envelope = xml.etree.ElementTree.Element(


### PR DESCRIPTION
The code removed here is overriding dividend payer title provided in `companies.xml` with just a stock title from IB flex report. Which I think is not what we want, so I removed it. Maybe I'm missing something?