### PR TITLE
nix: add flake and package

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if has nix; then
+  watch_file nix/package.nix
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 !companies.xml
 !ib-affiliates.xml
 !relief-statements.xml
+result
+.direnv

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ ib_edavki
 
 Odpri datoteko **taxpayer.xml** in vnesi svoje davčne podatke.
 
+#### Nix
+
+Skripto lahko zaženeš tudi direktno z [nix](https://nixos.org/), brez namestitve.
+
+```bash
+nix run github:jamsix/ib-edavki
+
+# V primeru, da želiš podati parametre
+nix run github:jamsix/ib-edavki -- ib-export-2020.xml ib-export-2021.xml
+```
+
 ### Izvoz poročila v platformi InteractiveBrokers
 
 1. V meniju **Performance & reports** odpri **Flex Queries**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "InteractiveBrokers -> FURS eDavki converter";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        ib-edavki = pkgs.callPackage ./nix/package.nix { };
+      in
+      {
+        packages = {
+          ib-edavki = ib-edavki;
+          default = ib-edavki;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ ib-edavki ];
+        };
+      }
+    );
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  python3,
+}:
+
+python3.pkgs.buildPythonPackage {
+  pname = "ib_edavki";
+  version = "1.4.8";
+  pyproject = true;
+
+  src = lib.cleanSource ../.;
+
+  build-system = [ python3.pkgs.setuptools ];
+
+  dependencies = with python3.pkgs; [
+    requests
+    certifi
+  ];
+
+  pythonImportsCheck = [ "ib_edavki" ];
+
+  meta = {
+    description = "Convert InteractiveBrokers XML reports to Slovenian tax forms (Doh-KDVP, D-IFI, D-Div, Doh-Obr)";
+    homepage = "https://github.com/jamsix/ib-edavki";
+    mainProgram = "ib_edavki";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
This PR adds nix flake support. This enables users to run the script without having pip or Python installed on their system.

Changes:
- Add `flake.nix` with dev shell and package outputs
- Add `nix/package.nix` package definition

Usage:
- `nix develop` - Enter development environment
- `nix build .#` - Build the package  
- `nix run .# -- file.xml` - Run directly