### PR TITLE
Added valid tax number for TSMC

### DIFF
--- a/companies.xml
+++ b/companies.xml
@@ -3305,7 +3305,7 @@
     <isin />
     <symbol>TSM</symbol>
     <name>Taiwan Semiconductor Manufacturing Company Limited</name>
-    <taxNumber>-</taxNumber>
+    <taxNumber>22099131</taxNumber>
     <address>Hsinchu Science Park No. 8, Li-Hsin Road 6 Hsinchu 300-78</address>
     <country>TW</country>
   </company>


### PR DESCRIPTION
I've been using this in my reports for multiple years. It's the only tax-related number I could find/validate with multiple sources, primarily here: https://www.leinumber.com/leicert/549300KB6NK5SBD14S87/